### PR TITLE
Linkable Text Field

### DIFF
--- a/WebVella.TagHelpers.Site/Pages/index.cshtml
+++ b/WebVella.TagHelpers.Site/Pages/index.cshtml
@@ -6,87 +6,88 @@
 @using Newtonsoft.Json;
 @using Microsoft.AspNetCore.Html;
 @{
-	Layout = null;
-	var apiUrl = "/";
-	var cb = DateTime.Now.ToString("yyyyMMddHHmmss");
-	var textFieldValue = "this is a test <script></script>";
-	var htmlValue = "<p>&lt;script&gt;</p>";
-	var chartDs = new WvChartDataset(){
-		BorderColor = "#FF9800",
-		Data = new List<decimal>{5,15,25}
-	};
-	var autoNumberValue = (decimal)1.00;
-	var autonumberTemplate = "boz-{0}";
-	var chartDsList = new List<WvChartDataset>{ chartDs};
+    Layout = null;
+    var apiUrl = "/";
+    var cb = DateTime.Now.ToString("yyyyMMddHHmmss");
+    var textFieldValue = "this is a test <script></script>";
+    var htmlValue = "<p>&lt;script&gt;</p>";
+    var chartDs = new WvChartDataset(){
+        BorderColor = "#FF9800",
+        Data = new List<decimal>{5,15,25}
+    };
+    var autoNumberValue = (decimal)1.00;
+    var autonumberTemplate = "boz-{0}";
+    var chartDsList = new List<WvChartDataset>{ chartDs};
 
-	var htmlEncoded = HttpUtility.HtmlEncode("<div class=\"text\">text<script></div>");
-	var colorVal = "#FF9800";
-	var chGridRows = new List<WvSelectOption>(){
-		new WvSelectOption(){Label = "row 1", Value = "row1"},
-		new WvSelectOption(){Label = "row 2", Value = "row2"},
-		new WvSelectOption(){Label = "row 3", Value = "row3"},
-	};
+    var htmlEncoded = HttpUtility.HtmlEncode("<div class=\"text\">text<script></div>");
+    var colorVal = "#FF9800";
+    var chGridRows = new List<WvSelectOption>(){
+        new WvSelectOption(){Label = "row 1", Value = "row1"},
+        new WvSelectOption(){Label = "row 2", Value = "row2"},
+        new WvSelectOption(){Label = "row 3", Value = "row3"},
+       
+    };
 
-	var chGridColumns = new List<WvSelectOption>(){
-		new WvSelectOption(){Label = "col 1", Value = "col1"},
-		new WvSelectOption(){Label = "col 2", Value = "col2"},
-		new WvSelectOption(){Label = "col 3", Value = "col3"},
-	};
+    var chGridColumns = new List<WvSelectOption>(){
+        new WvSelectOption(){Label = "col 1", Value = "col1"},
+        new WvSelectOption(){Label = "col 2", Value = "col2"},
+        new WvSelectOption(){Label = "col 3", Value = "col3"},
+    };
 
-	var chGridValues = new List<WvKeyStringList>(){
-		new WvKeyStringList(){Key = "row1",Values = new List<string>{"col1","col2"}}
-	};
+    var chGridValues = new List<WvKeyStringList>(){
+        new WvKeyStringList(){Key = "row1",Values = new List<string>{"col1","col2"}}
+    };
 
-	var chGridValuesJson = JsonConvert.SerializeObject(chGridValues);
+    var chGridValuesJson = JsonConvert.SerializeObject(chGridValues);
 
-	var chkBxList = new List<WvSelectOption>(){
-		new WvSelectOption(){Value = "1", Label = "one"},
-		new WvSelectOption(){Value = "2", Label = "two"},
-	};
+    var chkBxList = new List<WvSelectOption>(){
+        new WvSelectOption(){Value = "1", Label = "one"},
+        new WvSelectOption(){Value = "2", Label = "two"},
+    };
 
-	var chkBxListValues = new List<string>{"1"};
+    var chkBxListValues = new List<string>{"1"};
 
-	decimal decVal = (decimal)23.3434;
+    decimal decVal = (decimal)23.3434;
 
-	var emailVal = "test@domain.com ";
+    var emailVal = "test@domain.com ";
 
-	var fileVal = "/_content/WebVella.TagHelpers/assets/background.png";
-	var multiFilesVal = new List<string>{"/_content/WebVella.TagHelpers/assets/background1.png","/_content/WebVella.TagHelpers/assets/background2.png"};
-	var multiFilesValRecords = new List<dynamic>{
-		new {
-			path = "/_content/WebVella.TagHelpers/assets/background1.png",
-			name = "FileName1",
-			icon = "",
-			size = 345,
-			timestamp = DateTime.Now,
-			author = "Boz Zashev"
-		},
-		new {
-			path = "/_content/WebVella.TagHelpers/assets/background2.png",
-			name = "FileName2",
-			icon = "",
-			size = 58888
-		}
-	};
+    var fileVal = "/_content/WebVella.TagHelpers/assets/background.png";
+    var multiFilesVal = new List<string>{"/_content/WebVella.TagHelpers/assets/background1.png","/_content/WebVella.TagHelpers/assets/background2.png"};
+    var multiFilesValRecords = new List<dynamic>{
+        new {
+            path = "/_content/WebVella.TagHelpers/assets/background1.png",
+            name = "FileName1",
+            icon = "",
+            size = 345,
+            timestamp = DateTime.Now,
+            author = "Boz Zashev"
+        },
+        new {
+            path = "/_content/WebVella.TagHelpers/assets/background2.png",
+            name = "FileName2",
+            icon = "",
+            size = 58888
+        }
+    };
 
-	var guidVal = Guid.NewGuid();
+    var guidVal = Guid.NewGuid();
 
-	var iconVal = "fa fa-save";
-	var urlVal = "http://google.com";
+    var iconVal = "fa fa-save";
+    var urlVal = "http://google.com";
 
-	var gridColumns = new List<WvGridColumnMeta>{
-		new WvGridColumnMeta{
-			Name = "col1",
-			Label = "column 1"
-		}
-	};
-	var gridRecords = new List<string>{"one","two"};
+    var gridColumns = new List<WvGridColumnMeta>{
+        new WvGridColumnMeta{
+            Name = "col1",
+            Label = "column 1"
+        }
+    };
+    var gridRecords = new List<string>{"one","two"};
 
-	var valErrors = new List<KeyValuePair<string,string>>{
-		new KeyValuePair<string, string>("name","Name is required"),
-		new KeyValuePair<string, string>("email","Email is required")
-	};
-	var csvFieldValue = "1,2,3\r\njohn,eve,jim";
+    var valErrors = new List<KeyValuePair<string,string>>{
+        new KeyValuePair<string, string>("name","Name is required"),
+        new KeyValuePair<string, string>("email","Email is required")
+    };
+    var csvFieldValue = "1,2,3\r\njohn,eve,jim";
 }
 
 <!DOCTYPE html>
@@ -1454,7 +1455,7 @@
 					Form
 				</div>
 				<div class="card-body">
-					<wv-field-text size="Small" value="@textFieldValue" label-text="FieldLabel" name="text" mode="Form"></wv-field-text>
+					<wv-field-text size="Small" value="@textFieldValue" link="https://www.google.com" label-text="FieldLabel" name="text" mode="Form"></wv-field-text>
 				</div>
 			</div>
 		</div>
@@ -1464,7 +1465,7 @@
 					Inline Edit
 				</div>
 				<div class="card-body">
-					<wv-field-text value="@textFieldValue" label-text="FieldLabel" name="text" mode="InlineEdit" api-url="@apiUrl"></wv-field-text>
+					<wv-field-text value="@textFieldValue" label-text="FieldLabel" link="https://www.google.com" name="text" mode="InlineEdit" api-url="@apiUrl"></wv-field-text>
 				</div>
 			</div>
 		</div>
@@ -1474,7 +1475,7 @@
 					Display
 				</div>
 				<div class="card-body">
-					<wv-field-text value="@textFieldValue" label-text="FieldLabel" name="text" mode="Display"></wv-field-text>
+					<wv-field-text value="@textFieldValue" label-text="FieldLabel" link="https://www.google.com" name="text" mode="Display"></wv-field-text>
 				</div>
 			</div>
 		</div>
@@ -1484,7 +1485,7 @@
 					Display
 				</div>
 				<div class="card-body">
-					<wv-field-text value="@textFieldValue" label-text="FieldLabel" name="text" mode="Simple"></wv-field-text>
+					<wv-field-text value="@textFieldValue" label-text="FieldLabel" link="https://www.google.com" name="text" mode="Simple"></wv-field-text>
 				</div>
 			</div>
 		</div>

--- a/WebVella.TagHelpers/TagHelpers/WvFieldSelect/WvFieldSelect.cs
+++ b/WebVella.TagHelpers/TagHelpers/WvFieldSelect/WvFieldSelect.cs
@@ -28,6 +28,13 @@ namespace WebVella.TagHelpers.TagHelpers
 
 		[HtmlAttributeName("select-match-type")]
 		public WvSelectMatchType SelectMatchType { get; set; } = WvSelectMatchType.Contains;
+		/*
+		 * The link that will be opened.
+		 * Feature: LInkable Text Field
+		 *Author: Amarjeet-L
+		 */
+		[HtmlAttributeName("link")]
+		public string Link { get; set; } = null;
 
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
@@ -597,7 +604,22 @@ namespace WebVella.TagHelpers.TagHelpers
 						}
 						viewInputActionEl.InnerHtml.AppendHtml("<button type=\"button\" class='btn btn-white' title='edit'><i class='fa fa-fw fa-pencil-alt'></i></button>");
 						viewWrapperEl.InnerHtml.AppendHtml(viewInputActionEl);
-
+						/*
+					 * Append an anchor field with the provided link value, if it is present
+					 * Feature: LInkable Text Field
+					 *Author: Amarjeet-L
+					 */
+						if (Link != "" && Link != null)
+						{
+							var linkInputActionEl = new TagBuilder("span");
+							linkInputActionEl.AddCssClass("input-group-append");
+							foreach (var htmlString in AppendHtml)
+							{
+								linkInputActionEl.InnerHtml.AppendHtml(htmlString);
+							}
+							linkInputActionEl.InnerHtml.AppendHtml("<a href='" + Link + "' target='_blank' class='btn btn-white' title='details'><i class='fas fa-external-link-alt'></i></a>");
+							viewWrapperEl.InnerHtml.AppendHtml(linkInputActionEl);
+						}
 						output.Content.AppendHtml(viewWrapperEl);
 					}
 					#endregion

--- a/WebVella.TagHelpers/TagHelpers/WvFieldText/WvFieldText.cs
+++ b/WebVella.TagHelpers/TagHelpers/WvFieldText/WvFieldText.cs
@@ -19,6 +19,14 @@ namespace WebVella.TagHelpers.TagHelpers
 		[HtmlAttributeName("maxlength")]
 		public int? MaxLength { get; set; } = null;
 
+		/*
+		 * The link that will be opened.
+		 * Feature: LInkable Text Field
+		 *Author: Amarjeet-L
+		 */
+		[HtmlAttributeName("link")]
+		public string Link { get; set; } = null;
+
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
 			if (!isVisible)
@@ -196,7 +204,19 @@ namespace WebVella.TagHelpers.TagHelpers
 					if (Size == WvCssSize.Small)
 						divEl.AddCssClass("input-group-sm");
 
-					divEl.InnerHtml.Append((Value ?? "").ToString());
+					/*
+					 * Append an anchor field with the provided link value, if it is present
+					 * Feature: LInkable Text Field
+					 *Author: Amarjeet-L
+					 */
+					if (Link != null && Link != "")
+					{
+						divEl.InnerHtml.AppendHtml("<a href='" + Link + "' target='_blank'>" + (Value ?? "").ToString() + "</a>");
+					}
+					else
+					{
+						divEl.InnerHtml.Append((Value ?? "").ToString());
+					}
 					output.Content.AppendHtml(divEl);
 				}
 				else
@@ -207,7 +227,19 @@ namespace WebVella.TagHelpers.TagHelpers
 			else if (Mode == WvFieldRenderMode.Simple)
 			{
 				output.SuppressOutput();
-				output.Content.Append((Value ?? "").ToString());
+				/*
+					 * Append an anchor field with the provided link value, if it is present
+					 * Feature: LInkable Text Field
+					 *Author: Amarjeet-L
+					 */
+				if (Link != null && Link != "")
+				{
+					output.Content.AppendHtml("<a href='" + Link + "' target='_blank'>" + (Value ?? "").ToString() + "</a>");
+				}
+				else
+				{
+					output.Content.Append((Value ?? "").ToString());
+				}
 				return;
 			}
 			else if (Mode == WvFieldRenderMode.InlineEdit)
@@ -253,7 +285,22 @@ namespace WebVella.TagHelpers.TagHelpers
 						}
 						viewInputActionEl.InnerHtml.AppendHtml("<button type=\"button\" class='btn btn-white' title='edit'><i class='fa fa-fw fa-pencil-alt'></i></button>");
 						viewWrapperEl.InnerHtml.AppendHtml(viewInputActionEl);
-
+						/*
+							 * Append an anchor field with the provided link value, if it is present
+							 * Feature: LInkable Text Field
+							 *Author: Amarjeet-L
+							 */
+						if (Link != "" && Link != null)
+						{
+							var linkInputActionEl = new TagBuilder("span");
+							linkInputActionEl.AddCssClass("input-group-append");
+							foreach (var htmlString in AppendHtml)
+							{
+								linkInputActionEl.InnerHtml.AppendHtml(htmlString);
+							}
+							linkInputActionEl.InnerHtml.AppendHtml("<a href='" + Link + "' target='_blank' class='btn btn-white' title='details'><i class='fas fa-external-link-alt'></i></a>");
+							viewWrapperEl.InnerHtml.AppendHtml(linkInputActionEl);
+						}
 						output.Content.AppendHtml(viewWrapperEl);
 					}
 					#endregion
@@ -314,7 +361,7 @@ namespace WebVella.TagHelpers.TagHelpers
 
 						editInputGroupEl.InnerHtml.AppendHtml(editInputGroupAppendEl);
 						editWrapperEl.InnerHtml.AppendHtml(editInputGroupEl);
-
+						
 						output.Content.AppendHtml(editWrapperEl);
 					}
 					#endregion


### PR DESCRIPTION
To facilitate allowing text in a **wv-field-text** and **wv-field-select** to be linked to a a custom url.
Use case : 
Consider two entities Order and Product, with a relationship between Order and Product. The Order LIst page displays a grid with a column displaying the product name.  User needs to quickly and easily open the the product details page and see it's numerous fields ( The inventory for e.g.).
Possible solutions with existing code:
1. Add a button to the row or the cell which will open the details page - This causes loss of screen real estate and seems unintuitive
Proposed solution:
Add a new field (link) for the wv-field-text and wv-field-select tag. During render, if value is provided in the link field, append a anchor tag which will open the provided link when clicked. (E.g the text of the wv-field-text will show 'Apple' and when clicked on the link a new page with the details of the product apple( or whatever is provided in the link field are displayed)
In case of wv-select-field a button is displayed next to the field which works similar to above.

https://user-images.githubusercontent.com/42667223/113654532-ab2c8280-96b5-11eb-8dc1-2e5ef22c3479.mp4

